### PR TITLE
feat: add activity type

### DIFF
--- a/rpc/inputMapper.go
+++ b/rpc/inputMapper.go
@@ -26,6 +26,8 @@ type Activity struct {
 	Secrets *Secrets
 	// Clickable buttons that open a URL in the browser
 	Buttons []*Button
+	// The type of the activity, defaults to 0 (Playing) if not set
+	Type ActivityType
 }
 
 // Button holds a label and the corresponding URL that is opened on press
@@ -64,6 +66,16 @@ type Secrets struct {
 	Spectate string
 }
 
+/// ActivityType is the type of the activity (Playing, Listening, Watching, Competing)
+type ActivityType int
+
+const (
+	ActivityTypePlaying   ActivityType = 0
+	ActivityTypeListening ActivityType = 2
+	ActivityTypeWatching  ActivityType = 3
+	ActivityTypeCompeting ActivityType = 5
+)
+
 func mapActivity(activity *Activity) *PayloadActivity {
 	final := &PayloadActivity{
 		Details: activity.Details,
@@ -74,6 +86,7 @@ func mapActivity(activity *Activity) *PayloadActivity {
 			SmallImage: activity.SmallImage,
 			SmallText:  activity.SmallText,
 		},
+		Type: activity.Type,
 	}
 
 	if activity.Timestamps != nil && activity.Timestamps.Start != nil {

--- a/rpc/types.go
+++ b/rpc/types.go
@@ -26,6 +26,7 @@ type PayloadActivity struct {
 	Timestamps *PayloadTimestamps `json:"timestamps,omitempty"`
 	Secrets    *PayloadSecrets    `json:"secrets,omitempty"`
 	Buttons    []*PayloadButton   `json:"buttons,omitempty"`
+	Type       ActivityType       `json:"type,omitempty"`
 }
 
 type PayloadAssets struct {


### PR DESCRIPTION
Added the ability to supply a different activity type as Discord supports more activity types for RPC activities now https://discord.com/developers/docs/change-log#supported-activity-types-for-setactivity